### PR TITLE
Add git rebase before push in CI workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -58,4 +58,5 @@ jobs:
         git add .
         # Force the build to succeed, even if no files were changed
         git commit -m 'Update generated files' || true
+        git pull --rebase origin main
         git push


### PR DESCRIPTION
## Summary
Updated the GitHub Actions workflow to perform a git rebase before pushing changes, ensuring that generated files are rebased onto the latest main branch commits.

## Key Changes
- Added `git pull --rebase origin main` step before `git push` in the main workflow
- This ensures the workflow's commits are rebased on top of any new commits that may have been pushed to main since the workflow started

## Implementation Details
The rebase is performed after committing generated files but before pushing, which helps prevent merge conflicts and maintains a linear commit history when multiple workflows or contributors are pushing changes simultaneously.

https://claude.ai/code/session_013k9A6hvDwVyPaL3nYM3RP9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the automated commit workflow to synchronize with the main branch before pushing, ensuring the local branch is synchronized with the latest remote changes before code is pushed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->